### PR TITLE
Mirror of upstream PR #2535 (AI review sandbox)

### DIFF
--- a/letta/functions/mcp_client/sse_client.py
+++ b/letta/functions/mcp_client/sse_client.py
@@ -16,7 +16,8 @@ logger = get_logger(__name__)
 class SSEMCPClient(BaseMCPClient):
     def _initialize_connection(self, server_config: SSEServerConfig, timeout: float) -> bool:
         try:
-            sse_cm = sse_client(url=server_config.server_url)
+            sse_headers = {'Authorization': f'Bearer {server_config.token}'} if server_config.token else None
+            sse_cm = sse_client(url=server_config.server_url, headers=sse_headers)
             sse_transport = self.loop.run_until_complete(asyncio.wait_for(sse_cm.__aenter__(), timeout=timeout))
             self.stdio, self.write = sse_transport
             self.cleanup_funcs.append(lambda: self.loop.run_until_complete(sse_cm.__aexit__(None, None, None)))

--- a/letta/functions/mcp_client/types.py
+++ b/letta/functions/mcp_client/types.py
@@ -22,12 +22,15 @@ class BaseServerConfig(BaseModel):
 class SSEServerConfig(BaseServerConfig):
     type: MCPServerType = MCPServerType.SSE
     server_url: str = Field(..., description="The URL of the server (MCP SSE client will connect to this URL)")
+    token: Optional[str] = Field(None, description="The bearer token to use for authentication (if required)")
 
     def to_dict(self) -> dict:
         values = {
             "transport": "sse",
             "url": self.server_url,
         }
+        if self.token is not None:
+            values["token"] = self.token
         return values
 
 

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -1314,6 +1314,7 @@ class SyncServer(Server):
                                 server_params = SSEServerConfig(
                                     server_name=server_name,
                                     server_url=server_params_raw["url"],
+                                    token=server_params_raw.get("token"),
                                 )
                                 mcp_server_list[server_name] = server_params
                             except Exception as e:


### PR DESCRIPTION
Please describe the purpose of this pull request.
This PR adds bearer token pass-through for SSE MCP servers.

MCP Configs can take a value for token and that token will be passed to the MCP SSE Client as a bearer auth token header.

How to test

This can be tested by:

Set up an MCP server that expects a bearer token on the MCP /sse and /messages endpoints
(just to verify) connect to the MCP server with MCP Inspector with the bearer token to make sure the server is ready
Add the server URL to mcp_config.json along with a new parameter "token": "<foo>"
Start Letta and make sure Letta connects to the MCP server
Have you tested this PR?

Yes - MCP server and Letta started successfully following the above steps

Related issues or PRs
n/a

Is your PR over 500 lines of code?
No, +6/-1

Additional context
This is useful when connecting to a remote MCP server that requires authentication for security / privacy. The MCP SSEClient is ready to use the headers, all we need to do is pass them through.